### PR TITLE
Add CLI and config file options for CDP fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,32 @@ To manually start the script, run:
 sudo /usr/local/bin/cdp_sender.py
 ```
 
+## Configuration
+The script accepts command-line arguments to customize the CDP fields. View available options:
+```bash
+sudo /usr/local/bin/cdp_sender.py --help
+```
+Example:
+```bash
+sudo /usr/local/bin/cdp_sender.py --interface eth0 --device-id MyDevice --software-version "1.2.3" --platform "MyPlatform"
+```
+
+You can also provide a JSON configuration file:
+```json
+{
+  "interface": "eth0",
+  "device_id": "MyDevice",
+  "software_version": "1.2.3",
+  "platform": "MyPlatform",
+  "ttl": 120,
+  "capabilities": "0x0028"
+}
+```
+Run the script with:
+```bash
+sudo /usr/local/bin/cdp_sender.py --config config.json
+```
+
 ## Setting Up Automatic Execution with systemd
 To ensure the script starts at boot and runs continuously, follow these steps:
 

--- a/cdp_sender.py
+++ b/cdp_sender.py
@@ -1,44 +1,55 @@
 from scapy.all import *
 from scapy.layers.l2 import Ether, SNAP, LLC
-from scapy.contrib.cdp import (CDPv2_HDR, CDPMsgDeviceID, CDPMsgPortID, 
-                              CDPMsgSoftwareVersion, CDPMsgPlatform, CDPMsgAddr,
-                              CDPAddrRecordIPv4, CDPMsgCapabilities)
+from scapy.contrib.cdp import (
+    CDPv2_HDR,
+    CDPMsgDeviceID,
+    CDPMsgPortID,
+    CDPMsgSoftwareVersion,
+    CDPMsgPlatform,
+    CDPMsgAddr,
+    CDPAddrRecordIPv4,
+    CDPMsgCapabilities,
+)
+import argparse
+import json
 import time
 
-def send_cdp_packet(interface):
+
+def send_cdp_packet(interface, device_id, software_version, platform, ttl, capabilities):
+    """Send a CDP packet with customizable fields."""
     # Get the MAC address and IP of the interface
     src_mac = get_if_hwaddr(interface)
     src_ip = get_if_addr(interface)
     print(f"Using source MAC address: {src_mac}")
     print(f"Using source IP address: {src_ip}")
-    
+
     # Create base packet with CDP multicast address and correct source MAC
     eth = Ether(dst='01:00:0c:cc:cc:cc', src=src_mac)
     llc = LLC(dsap=0xaa, ssap=0xaa, ctrl=3)
     snap = SNAP(OUI=0x00000c, code=0x2000)
-    
+
     # Create the address record
     addr_record = CDPAddrRecordIPv4(addr=src_ip)
-    
+
     cdp = CDPv2_HDR(
-        ttl=180,  # 180 seconds TTL
+        ttl=ttl,
         msg=[
-            CDPMsgDeviceID(val='Cisco_AP_01'),
+            CDPMsgDeviceID(val=device_id),
             CDPMsgAddr(
                 naddr=1,
                 addr=[addr_record]
             ),
             CDPMsgCapabilities(
-                cap=0x0028    # Set capabilities for AP (0x0028 = Host + IGMP capabilities)
+                cap=capabilities
             ),
-            CDPMsgSoftwareVersion(val='AP Software 8.5.1'),
-            CDPMsgPlatform(val='Cisco Aironet 2800'),
+            CDPMsgSoftwareVersion(val=software_version),
+            CDPMsgPlatform(val=platform),
             CDPMsgPortID(iface=interface)
         ]
     )
-    
+
     packet = eth/llc/snap/cdp
-    
+
     try:
         while True:
             sendp(packet, iface=interface, verbose=False)
@@ -49,12 +60,47 @@ def send_cdp_packet(interface):
     except Exception as e:
         print(f"Error sending packet: {e}")
 
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Send customizable CDP packets.")
+    parser.add_argument("--interface", default="eth0", help="Interface to send CDP packets on.")
+    parser.add_argument("--device-id", dest="device_id", default="Cisco_AP_01", help="Device ID to advertise.")
+    parser.add_argument("--software-version", dest="software_version", default="AP Software 8.5.1", help="Software version string.")
+    parser.add_argument("--platform", default="Cisco Aironet 2800", help="Platform string.")
+    parser.add_argument("--ttl", type=int, default=180, help="TTL in seconds.")
+    parser.add_argument(
+        "--capabilities",
+        type=lambda x: int(x, 0),
+        default=0x0028,
+        help="Capabilities bitmap (e.g., 0x0028).",
+    )
+    parser.add_argument("--config", help="Path to JSON file with default argument values.")
+    args = parser.parse_args()
+    if args.config:
+        with open(args.config) as f:
+            cfg = json.load(f)
+        for field in ["interface", "device_id", "software_version", "platform", "ttl", "capabilities"]:
+            if field in cfg and getattr(args, field) == parser.get_default(field):
+                value = cfg[field]
+                if field in {"ttl", "capabilities"} and isinstance(value, str):
+                    value = int(value, 0)
+                setattr(args, field, value)
+    return args
+
+
 if __name__ == "__main__":
+    args = parse_args()
     # List available interfaces
     print("Available interfaces:")
     print(get_if_list())
-    
-    interface = "eth0"  # Change to your interface
-    print(f"Starting CDP sender on {interface}")
+
+    print(f"Starting CDP sender on {args.interface}")
     print("Press Ctrl+C to stop")
-    send_cdp_packet(interface)
+    send_cdp_packet(
+        interface=args.interface,
+        device_id=args.device_id,
+        software_version=args.software_version,
+        platform=args.platform,
+        ttl=args.ttl,
+        capabilities=args.capabilities,
+    )


### PR DESCRIPTION
## Summary
- Allow customizing CDP fields such as device ID, software version, platform, TTL and capabilities via command-line options or a JSON config file.
- Document new configuration options in README.

## Testing
- `python -m py_compile cdp_sender.py`
- `python cdp_sender.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68b6c2d8b7b8832a85443d61eb8a9855