### PR TITLE
Add CI workflow for tests and builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install package and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest
+      - name: Run tests
+        run: |
+          python -m pytest
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: |
+          python -m build
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.build/
+build/
+dist/
+*.egg-info/
+.pytest_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "scapy-cdp-sender"
+version = "0.1.0"
+description = "Send customizable CDP packets using scapy"
+readme = "README.md"
+authors = [{name = "Unknown"}]
+requires-python = ">=3.8"
+dependencies = [
+    "scapy"
+]
+
+[tool.setuptools]
+py-modules = ["cdp_sender"]

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -1,0 +1,23 @@
+import json
+import sys
+import cdp_sender
+
+def test_parse_args_config_file(tmp_path, monkeypatch):
+    cfg = {
+        "interface": "eth1",
+        "device_id": "DeviceX",
+        "software_version": "v1",
+        "platform": "PlatformX",
+        "ttl": 100,
+        "capabilities": "0x0001",
+    }
+    config_file = tmp_path / "cfg.json"
+    config_file.write_text(json.dumps(cfg))
+    monkeypatch.setattr(sys, "argv", ["cdp_sender.py", "--config", str(config_file)])
+    args = cdp_sender.parse_args()
+    assert args.interface == "eth1"
+    assert args.device_id == "DeviceX"
+    assert args.software_version == "v1"
+    assert args.platform == "PlatformX"
+    assert args.ttl == 100
+    assert args.capabilities == 0x0001


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests and build artifacts

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6c7d82fd8832ab63b3fad124045ed