### PR TITLE
Package CDP sender as installable module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,32 @@
-# CDP Sender Script Instructions
+# CDP Sender Module
 
 ## Overview
-This guide explains how to set up and use a CDP (Cisco Discovery Protocol) sender script on Kali Linux. The script uses **Scapy** to send CDP packets every 60 seconds.
+`scapy-cdp` provides a small command line utility to send Cisco Discovery Protocol (CDP) packets using [Scapy](https://scapy.net/). It installs a `cdp-sender` command that transmits a CDP packet every 60 seconds. The module works well on Linux systems, including Raspberry Pi.
 
-## Prerequisites
-Ensure you have the following installed:
+## Installation
+Install the package with `pip`:
 
-- Python 3
-- Scapy
-- Systemd (for automatic startup)
-
-### Install Scapy (if not installed)
 ```bash
-sudo apt update
-sudo apt install python3-scapy -y
+sudo pip3 install scapy-cdp
 ```
 
-## Script Location
-The script should be stored at:
+This creates the `/usr/local/bin/cdp-sender` executable.
+
+## Usage
+Display available options:
+
 ```bash
-/usr/local/bin/cdp_sender.py
+sudo cdp-sender --help
 ```
 
-### Grant Execution Permission
-```bash
-sudo chmod +x /usr/local/bin/cdp_sender.py
-```
-
-## Running the Script Manually
-To manually start the script, run:
-```bash
-sudo /usr/local/bin/cdp_sender.py
-```
-
-## Configuration
-The script accepts command-line arguments to customize the CDP fields. View available options:
-```bash
-sudo /usr/local/bin/cdp_sender.py --help
-```
 Example:
+
 ```bash
-sudo /usr/local/bin/cdp_sender.py --interface eth0 --device-id MyDevice --software-version "1.2.3" --platform "MyPlatform"
+sudo cdp-sender --interface eth0 --device-id MyDevice --software-version "1.2.3" --platform "MyPlatform"
 ```
 
-You can also provide a JSON configuration file:
+Settings can also come from a JSON configuration file:
+
 ```json
 {
   "interface": "eth0",
@@ -54,28 +37,23 @@ You can also provide a JSON configuration file:
   "capabilities": "0x0028"
 }
 ```
-Run the script with:
+
+Run with the configuration file:
+
 ```bash
-sudo /usr/local/bin/cdp_sender.py --config config.json
+sudo cdp-sender --config config.json
 ```
 
-## Setting Up Automatic Execution with systemd
-To ensure the script starts at boot and runs continuously, follow these steps:
+## Systemd Service
+Create `/etc/systemd/system/cdp_sender.service`:
 
-### 1. Create a Systemd Service File
-Create the service file:
-```bash
-sudo nano /etc/systemd/system/cdp_sender.service
-```
-
-### 2. Add the Following Content
 ```ini
 [Unit]
 Description=CDP Sender Service
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/cdp_sender.py
+ExecStart=/usr/local/bin/cdp-sender
 Restart=always
 User=root
 
@@ -83,51 +61,26 @@ User=root
 WantedBy=multi-user.target
 ```
 
-Save and exit (`CTRL+X`, `Y`, `Enter`).
+Then enable and start the service:
 
-### 3. Enable and Start the Service
-Reload systemd and enable the service:
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl enable cdp_sender
 sudo systemctl start cdp_sender
 ```
 
-### 4. Check Service Status
-To verify that the service is running:
-```bash
-sudo systemctl status cdp_sender
-```
+## Cron Alternative
+To run the script every minute with cron:
 
-## Logs and Debugging
-To check real-time logs:
-```bash
-journalctl -u cdp_sender -f
-```
-
-To restart the service:
-```bash
-sudo systemctl restart cdp_sender
-```
-
-To stop the service:
-```bash
-sudo systemctl stop cdp_sender
-```
-
-## Alternative: Using Cron
-If you prefer to use cron instead of systemd, add the following entry:
 ```bash
 sudo crontab -e
 ```
-Add this line at the end:
+
+Add this line:
+
 ```bash
-* * * * * /usr/local/bin/cdp_sender.py
+* * * * * /usr/local/bin/cdp-sender
 ```
-This will run the script every minute.
 
-## Conclusion
-By following these steps, Kali Linux will automatically send CDP packets every 60 seconds. You can choose between **systemd** for continuous execution or **cron** for periodic execution.
-
-Enjoy your CDP sender automation! 🚀
-
+## License
+MIT

--- a/cdp_sender.service
+++ b/cdp_sender.service
@@ -3,7 +3,7 @@ Description=CDP Sender Service
 After=network.target
 
 [Service]
-ExecStart=/usr/local/bin/cdp_sender.py
+ExecStart=/usr/local/bin/cdp-sender
 Restart=always
 User=root
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "scapy-cdp"
+version = "0.1.0"
+description = "Send Cisco Discovery Protocol packets with Scapy"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = ["scapy"]
+authors = [{ name = "CDP Maintainers" }]
+license = { text = "MIT" }
+
+[project.scripts]
+cdp-sender = "scapy_cdp.cdp_sender:main"

--- a/scapy_cdp/__init__.py
+++ b/scapy_cdp/__init__.py
@@ -1,0 +1,9 @@
+"""Utilities to send Cisco Discovery Protocol (CDP) packets using Scapy."""
+
+from .cdp_sender import send_cdp_packet, parse_args, main
+
+__all__ = [
+    "send_cdp_packet",
+    "parse_args",
+    "main",
+]

--- a/scapy_cdp/cdp_sender.py
+++ b/scapy_cdp/cdp_sender.py
@@ -24,9 +24,9 @@ def send_cdp_packet(interface, device_id, software_version, platform, ttl, capab
     print(f"Using source IP address: {src_ip}")
 
     # Create base packet with CDP multicast address and correct source MAC
-    eth = Ether(dst='01:00:0c:cc:cc:cc', src=src_mac)
-    llc = LLC(dsap=0xaa, ssap=0xaa, ctrl=3)
-    snap = SNAP(OUI=0x00000c, code=0x2000)
+    eth = Ether(dst="01:00:0c:cc:cc:cc", src=src_mac)
+    llc = LLC(dsap=0xAA, ssap=0xAA, ctrl=3)
+    snap = SNAP(OUI=0x00000C, code=0x2000)
 
     # Create the address record
     addr_record = CDPAddrRecordIPv4(addr=src_ip)
@@ -35,29 +35,26 @@ def send_cdp_packet(interface, device_id, software_version, platform, ttl, capab
         ttl=ttl,
         msg=[
             CDPMsgDeviceID(val=device_id),
-            CDPMsgAddr(
-                naddr=1,
-                addr=[addr_record]
-            ),
-            CDPMsgCapabilities(
-                cap=capabilities
-            ),
+            CDPMsgAddr(naddr=1, addr=[addr_record]),
+            CDPMsgCapabilities(cap=capabilities),
             CDPMsgSoftwareVersion(val=software_version),
             CDPMsgPlatform(val=platform),
-            CDPMsgPortID(iface=interface)
-        ]
+            CDPMsgPortID(iface=interface),
+        ],
     )
 
-    packet = eth/llc/snap/cdp
+    packet = eth / llc / snap / cdp
 
     try:
         while True:
             sendp(packet, iface=interface, verbose=False)
-            print(f"CDP packet sent on interface {interface} at {time.strftime('%H:%M:%S')}")
+            print(
+                f"CDP packet sent on interface {interface} at {time.strftime('%H:%M:%S')}"
+            )
             time.sleep(60)  # Wait 60 seconds before next packet
     except KeyboardInterrupt:
         print("\nStopping CDP sender...")
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - runtime safeguard
         print(f"Error sending packet: {e}")
 
 
@@ -88,8 +85,10 @@ def parse_args():
     return args
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Entry point for the ``cdp-sender`` console script."""
     args = parse_args()
+
     # List available interfaces
     print("Available interfaces:")
     print(get_if_list())
@@ -104,3 +103,7 @@ if __name__ == "__main__":
         ttl=args.ttl,
         capabilities=args.capabilities,
     )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()


### PR DESCRIPTION
## Summary
- package CDP sender as a Python module with a console script
- document installation and systemd usage for Raspberry Pi

## Testing
- `python -m py_compile scapy_cdp/cdp_sender.py scapy_cdp/__init__.py`
- `pip install -e .`
- `cdp-sender --help`


------
https://chatgpt.com/codex/tasks/task_e_68b6c40d81ec832a9b9091be2c1d8af2