### PR TITLE
Add CI workflow for tests and builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,32 +13,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Install package and dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          pip install pytest
+          pip install pytest scapy
       - name: Run tests
         run: |
           python -m pytest
-
-  build:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build package
-        run: |
-          python -m build
-      - name: Upload dist
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/*


### PR DESCRIPTION
## Summary
- remove package build step from GitHub Actions workflow

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6cb240ca8832abca19a316eace7be