### PR TITLE
Add build step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install . pytest
+      - name: Run tests
+        run: |
+          pytest || if [ $? -eq 5 ]; then echo "No tests collected"; else exit $?; fi
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: |
+          python -m build
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run tests
- build the project package and upload the distribution artifact

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6ce35b0e8832a8a5da1850be30bde