### PR TITLE
Add release job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,16 @@ jobs:
         with:
           name: dist
           path: dist/*
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*


### PR DESCRIPTION
## Summary
- add release job to CI workflow that publishes build artifacts when tags are pushed

## Testing
- `pytest`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_68b6d02ed168832aa19e2de6dc01bd0f