### PR TITLE
Install package with test extras in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-      - name: Install dependencies
+      - name: Install package
         run: |
           python -m pip install --upgrade pip
-          pip install pytest scapy
+          pip install .[test]
       - name: Run tests
         run: |
           python -m pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,10 @@ dependencies = [
     "scapy"
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest"
+]
+
 [tool.setuptools]
 py-modules = ["cdp_sender"]


### PR DESCRIPTION
## Summary
- install this project with its test extras in the CI workflow
- define `test` optional dependency containing pytest

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d230501c832aae19b48751e90bef