### PR TITLE
Include Host bit in default CDP capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Settings can also come from a JSON configuration file:
   "software_version": "1.2.3",
   "platform": "MyPlatform",
   "ttl": 120,
-  "capabilities": "0x0028"
+  "capabilities": "0x0038"
 }
 ```
 

--- a/scapy_cdp/cdp_sender.py
+++ b/scapy_cdp/cdp_sender.py
@@ -68,8 +68,8 @@ def parse_args():
     parser.add_argument(
         "--capabilities",
         type=lambda x: int(x, 0),
-        default=0x0028,
-        help="Capabilities bitmap (e.g., 0x0028).",
+        default=0x0038,
+        help="Capabilities bitmap (e.g., 0x0038).",
     )
     parser.add_argument("--config", help="Path to JSON file with default argument values.")
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- default CDP capabilities now include the Host bit (0x0038)
- update documentation to reference new default capability bitmap

## Testing
- `python -m py_compile scapy_cdp/cdp_sender.py scapy_cdp/cdp.py scapy_cdp/__init__.py`
- `python scapy_cdp/cdp_sender.py --help`
- `timeout 3 python scapy_cdp/cdp_sender.py --ttl 1`


------
https://chatgpt.com/codex/tasks/task_e_68b6e4ef54f8832a83a771f304c4b74f