### PR TITLE
Order CDP TLVs according to spec

### DIFF
--- a/scapy_cdp/cdp_sender.py
+++ b/scapy_cdp/cdp_sender.py
@@ -36,10 +36,10 @@ def send_cdp_packet(interface, device_id, software_version, platform, ttl, capab
         msg=[
             CDPMsgDeviceID(val=device_id),
             CDPMsgAddr(naddr=1, addr=[addr_record]),
+            CDPMsgPortID(iface=interface),
             CDPMsgCapabilities(cap=capabilities),
             CDPMsgSoftwareVersion(val=software_version),
             CDPMsgPlatform(val=platform),
-            CDPMsgPortID(iface=interface),
         ],
     )
 


### PR DESCRIPTION
## Summary
- Arrange CDP TLVs in correct order: DeviceID, Address, PortID, Capabilities, optional SoftwareVersion and Platform

## Testing
- `python -m py_compile scapy_cdp/cdp_sender.py`
- `pytest -q`
- `pip install -e .`
- `systemctl daemon-reload` *(fails: System has not been booted with systemd as init system)*
- `systemctl restart cdp_sender.service` *(fails: System has not been booted with systemd as init system)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e690d0cc832aabc824cec28eca3e