### PR TITLE
Add example script using scapy-cdp

### DIFF
--- a/examples/send_cdp_example.py
+++ b/examples/send_cdp_example.py
@@ -1,0 +1,15 @@
+"""Simple example script using scapy-cdp to send CDP packets."""
+
+from scapy_cdp.cdp_sender import send_cdp_packet
+
+
+if __name__ == "__main__":
+    # Adjust the parameters below as needed for your environment.
+    send_cdp_packet(
+        interface="eth0",
+        device_id="MyDevice",
+        software_version="1.2.3",
+        platform="MyPlatform",
+        ttl=120,
+        capabilities=0x0038,
+    )


### PR DESCRIPTION
## Summary
- add simple example script demonstrating how to send CDP packets with scapy-cdp

## Testing
- `python -m py_compile examples/send_cdp_example.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6faa91150832aaa78aabace3d5ec1