### PR TITLE
docs: clarify PATH for cdp-sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ sudo pip3 install scapy-cdp
 
 This creates the `/usr/local/bin/cdp-sender` executable.
 
+After installation, ensure the directory containing the executable is on your
+`PATH` so that the `cdp-sender` command is recognized without specifying the
+full path. For example, if pip installs to `/usr/local/bin`:
+
+```bash
+export PATH="$PATH:/usr/local/bin"
+```
+
+Users of tools like **pyenv** may also need to run `pyenv rehash` after
+installing to refresh shims for new commands.
+
 ## Usage
 Display available options:
 


### PR DESCRIPTION
## Summary
- Document how to add the installation directory to `PATH`
- Note that pyenv users may need to run `pyenv rehash`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `cdp-sender --help`


------
https://chatgpt.com/codex/tasks/task_e_68b6fa708f28832a8077186b51af9c30